### PR TITLE
chmod eslint for yarn

### DIFF
--- a/lib/postinstall.js
+++ b/lib/postinstall.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// gives eslint correct permissions since yarn installs it without executable
+// rights
+const { spawn } = require('child_process');
+
+spawn('chmod', [
+    '655',
+    require.resolve('eslint/bin/eslint')
+]);

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   },
   "bin": {
     "dibslint": "./index.js"
+  },
+  "scripts": {
+    "postinstall": "node ./lib/postinstall"
   }
 }


### PR DESCRIPTION
yarn has a bug where deps of deps bin files don't have the correct file permission settings.  This is a workaround.